### PR TITLE
do not remove csv files

### DIFF
--- a/BlobHunter.py
+++ b/BlobHunter.py
@@ -132,12 +132,6 @@ def check_subscription(tenant_id, tenant_name, sub_id, sub_name, creds):
     write_csv('public-containers-{}.csv'.format(date.today()), header, output_list)
 
 
-def delete_csv():
-    for file in os.listdir("."):
-        if os.path.isfile(file) and file.startswith("public"):
-            os.remove(file)
-
-
 def write_csv(file_name, header, rows):
     file_exists = os.path.isfile(file_name)
 
@@ -202,7 +196,6 @@ def print_logo():
 def main():
     print_logo()
     credentials = get_credentials()
-    delete_csv()
 
     if credentials is None:
         print("[-] Unable to login to a valid Azure user", flush=True)


### PR DESCRIPTION
I see two issues with removing CSV files.

1. This removes more files than are created with this tool.  The tool writes `public-containers-{date.today()}`, however the existing deletion is effectively `rm public*`
2. By removing the output from previous runs, users are unable to compare the changes from day-to-day.

This PR removes the deletion all together.